### PR TITLE
webserver: build wasm on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,6 @@ $ zig build
 
 # Run an HTTP server
 $ zig build serve
+
+# NOTE that the HTTP server will automatically rebuild the game whenever it is fetched
 ```

--- a/build.zig
+++ b/build.zig
@@ -7,6 +7,7 @@ pub fn build(b: *std.build.Builder) void {
     wasm.setBuildMode(mode);
     wasm.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
     wasm.install();
+    b.step("wasm", "build/install the wasm file").dependOn(&wasm.install_step.?.step);
 
     {
         const apple_pie = GitRepoStep.create(b, .{

--- a/index.html
+++ b/index.html
@@ -171,8 +171,18 @@
     });
 
     function fetchAndInstantiate(url, importObject) {
-      return fetch(url)
-        .then(response => response.arrayBuffer())
+        return fetch(url)
+        .then(response => {
+            if (response.headers.get("content-type") == "application/wasm")
+                return response.arrayBuffer();
+
+            response.text().then(text => {
+                var html = '<h1>Fetch ' + url + ' failed:</h1>';
+                html += '<pre>' + text + '</pre>';
+                document.body.innerHTML = html;
+            });
+            throw Error("failed to fetch wasm file");
+        })
         .then(bytes => WebAssembly.instantiate(bytes, importObject))
         .then(results => results.instance);
     }

--- a/webserver.zig
+++ b/webserver.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const http = @import("apple_pie");
 
-const Context = struct { };
+const Context = struct { repo_root: []const u8 };
 
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
@@ -15,16 +15,18 @@ pub fn main() !void {
         std.log.err("expected 1 cmdline argument but got {}", .{args.len});
         std.os.exit(0xff);
     }
-    const dir_path = args[0];
-    
+    const repo_root = args[0];
+
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const listen_addr = try std.net.Address.parseIp("127.0.0.1", 8080);
     try http.FileServer.init(gpa.allocator(), .{
-        .dir_path = dir_path,
+        .dir_path = repo_root,
         .base_path = null,
     });
-    const my_context = Context{ };
+    const my_context = Context{
+        .repo_root = repo_root,
+    };
     std.log.info("webserver started at '{}'", .{listen_addr});
     try http.listenAndServe(
         gpa.allocator(),
@@ -35,6 +37,39 @@ pub fn main() !void {
 }
 
 fn index(ctx: Context, response: *http.Response, request: http.Request) !void {
-    _ = ctx;
+    const path = request.context.uri.path;
+
+    if (std.mem.eql(u8, path, "/zig-out/lib/main.wasm")) {
+        //std.log.debug("running zig build...", .{});
+        const response_stream = response.writer();
+        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer arena.deinit();
+        const result = std.ChildProcess.exec(.{
+            .allocator = arena.allocator(),
+            .argv = &[_][]const u8 {
+                "zig", "build", "wasm",
+            },
+            .cwd = ctx.repo_root,
+        }) catch |err| {
+            try response_stream.print("exec 'zig build wasm' failed with error '{s}'", .{@errorName(err)});
+            return;
+        };
+        const success = switch (result.term) {
+            .Exited => |code| code == 0,
+            else => false,
+        };
+        if (!success) {
+            const sep: []const u8 = if (result.stdout.len > 0 and !std.mem.endsWith(u8, result.stdout, "\n")) "\n" else "";
+            try response_stream.print(
+                \\zig build wasm failed with:
+                \\-------------------------------------------------------------------------------
+                \\{s}{s}{s}
+                \\--------------------------------------------------------------------------------
+                \\
+                , .{result.stdout, sep, result.stderr});
+            return;
+        }
+    }
+
     try http.FileServer.serve({}, response, request);
 }


### PR DESCRIPTION
Webserver will now run "zig build wasm" before sending the `zig-out/lib/main.wasm` file.

Also, if "zig build wasm" fails, it will send the output to the client which will display an error like this:
![Screenshot from 2022-11-02 07-46-56](https://user-images.githubusercontent.com/304904/199505905-a3baa9ba-af4b-4b0b-8202-67a43f25b231.png)
